### PR TITLE
refactor(definitions): Add pending run history screen

### DIFF
--- a/app/definitions/schema.py
+++ b/app/definitions/schema.py
@@ -182,7 +182,8 @@ class DatastoreType(AuthNode, DjangoObjectType):
 
     has_indexes = graphene.Boolean()
     has_constraints = graphene.Boolean()
-    has_completed_run = graphene.Boolean()
+
+    first_run_is_pending = graphene.Boolean()
 
     class Meta:
         model = models.Datastore
@@ -239,7 +240,7 @@ class DatastoreType(AuthNode, DjangoObjectType):
         """
         return get_inspector_class(instance.engine).has_indexes()
 
-    def resolve_has_completed_run(instance, info):
+    def resolve_first_run_is_pending(instance, info):
         """Check if the datastore has a completed run.
         """
-        return instance.has_completed_run
+        return not instance.has_completed_run and not instance.schemas.count()

--- a/cypress.json
+++ b/cypress.json
@@ -12,6 +12,11 @@
   "viewportWidth": 1600,
   "viewportHeight": 1024,
   "testFiles": [
+    "datastore_overview.spec.js",
+    "datastore_properties.spec.js",
+    "table_overview.spec.js",
+    "table_properties.spec.js",
+    "table_indexes.spec.js",
     "authentication.spec.js",
     "customfields.spec.js",
     "sso.spec.js",

--- a/www/cypress/integration/table_columns.spec.js
+++ b/www/cypress/integration/table_columns.spec.js
@@ -115,12 +115,13 @@ describe("table_columns.spec.js", () => {
           })
 
           cy.get("td").eq(5).click()
-          cy.get("td").eq(descIndex).find(".editable-cell-value-wrap").should("have.value", "")
         })
 
         cy.contains(".ant-message-success", "Description was saved.").should(
           "be.visible"
         )
+
+        testTableColumnValue("customernumber", () => cy.get("td").eq(descIndex).should("have.value", ""))
 
         // Should persist after reload.
         cy.reload().then(() =>
@@ -137,12 +138,16 @@ describe("table_columns.spec.js", () => {
           })
 
           cy.get("td").eq(5).click()
-          cy.get("td").eq(descIndex).find(".editable-cell-value-wrap").should("have.value", "")
         })
 
-        cy.contains(".ant-message-error", "Column description cannot be longer than 90 characters.").should(
+        cy.contains(
+          ".ant-message-error",
+          "Column description cannot be longer than 90 characters."
+        ).should(
           "be.visible"
         )
+
+        testTableColumnValue("phone", () => cy.get("td").eq(descIndex).should("have.value", ""))
 
         // Should persist after reload.
         cy.reload().then(() =>

--- a/www/src/app/Datastores/DatastoreAssets/DatastoreAssetsTable.js
+++ b/www/src/app/Datastores/DatastoreAssets/DatastoreAssetsTable.js
@@ -4,9 +4,9 @@ import { withUserContext } from "context/UserContext"
 import { withRouter, Link } from "react-router-dom"
 import { withWriteAccess } from "hoc/withPermissionsRequired"
 import { Table } from "antd"
-
 import { map, uniqBy, flatten } from "lodash"
 import { components } from "app/Common/EditableCell"
+import FirstRunPending from "app/Datastores/RunHistory/FirstRunPending"
 import UpdateTableMetadata from "graphql/mutations/UpdateTableMetadata"
 import withGraphQLMutation from "hoc/withGraphQLMutation"
 
@@ -105,7 +105,7 @@ class DatastoreAssetsTable extends Component {
   }
 
   render() {
-    const { hasPermission } = this.props
+    const { datastore, hasPermission } = this.props
     const { dataSource } = this.state
 
     const columns = this.columns.map((col) => {
@@ -123,6 +123,10 @@ class DatastoreAssetsTable extends Component {
         }),
       }
     })
+
+    if (datastore.firstRunIsPending) {
+      return <FirstRunPending datastore={datastore} />
+    }
 
     return (
       <span data-test="DatastoreAssetsTable">

--- a/www/src/app/Datastores/RunHistory/FirstRunPending.js
+++ b/www/src/app/Datastores/RunHistory/FirstRunPending.js
@@ -1,7 +1,18 @@
 import React from "react"
+import { Icon, Spin } from "antd"
+import Link from "app/Navigation/Link"
 
-const FirstRunPending = ({ run }) => (
-  <span className="datastore-engine-icon">pending</span>
+const FirstRunPending = ({ datastore }) => (
+  <div className="first-run-pending">
+    <h3>
+        Metamapper is scanning and indexing your datastore.
+    </h3>
+    <p>
+        This might take a few minutes. You can monitor progress
+        from the <Link to={`/datastores/${datastore.slug}/runs`}>Run History</Link> page.
+    </p>
+    <Spin indicator={<Icon type="loading" spin style={{ fontSize: 48 }} />} />
+  </div>
 )
 
 export default FirstRunPending

--- a/www/src/graphql/queries/GetDatastoreWithTableList.js
+++ b/www/src/graphql/queries/GetDatastoreWithTableList.js
@@ -25,6 +25,7 @@ export default gql`
           shortDesc
         }
       }
+      firstRunIsPending
       latestRun {
         createdOn
         finishedAt

--- a/www/src/pages/Datastores/_datastores.scss
+++ b/www/src/pages/Datastores/_datastores.scss
@@ -106,6 +106,13 @@
   border: 1px solid #e8e8e8;
   border-bottom: 0;
 }
+.first-run-pending {
+  text-align: center;
+  margin-top: 24px;
+  .ant-spin.ant-spin-spinning {
+    margin-top: 24px;
+  }
+}
 .datastore-engine-icon {
   .ant-avatar {
     border-radius: 0;
@@ -265,7 +272,7 @@
   }
 }
 .table-definition-details {
-  border: 0; 
+  border: 0;
   border-bottom: 1px solid #e8e8e8;
   h3 {
     margin-bottom: 0;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Feature

## Description

Whenever someone creates a new datastore, we do not have any metadata about schemas, tables, etc. for a few minutes until the first revisioner run is complete. This can be odd for users when they navigate to the Data Assets page, which would just return a blank table.

This PR adds a "First run is pending..." screen until either (1) a run has completed or (2) some metadata is available.

![Untitled](https://user-images.githubusercontent.com/2450013/84962416-a4e40000-b0bb-11ea-8e79-3c050ce741ea.png)
